### PR TITLE
Use `npm start` to launch server application

### DIFF
--- a/fig.yml
+++ b/fig.yml
@@ -13,7 +13,7 @@ server:
   #Right now docker-sails supports 3 different tags:
   #0.10.32 (node 0.10.32), stable (latest node 0.10.x), latest (latest node 0.11.x)
   image: artificial/docker-sails:stable
-  command: sails lift
+  command: npm start
   volumes:
     - server/:/server
   ports:


### PR DESCRIPTION
When using docker, the "grunt" sub process of `sails lift` is causing gradually increasing CPU use.  I left it running over night, and my mac's poor little fan was about to explode.
