### PR TITLE
Add .editorconfig to help code consistency

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+# editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = false


### PR DESCRIPTION
Helps maintain file formatting rules in various editors.  For instance,
I use the Github Atom editor, to install:

`$ apm install editorconfig`
