### PR TITLE
added pod support

### DIFF
--- a/bin/sane
+++ b/bin/sane
@@ -71,9 +71,10 @@ program
 program
 .command('generate <blueprint> [name] [attributes...]')
 .option('-d, --docker [boolean]', 'Run Sails server and dependencies within docker containers.', config.docker || false)
+.option('-pod --pod [boolean]', 'Places newly generated resource in an Ember pod')
 .alias('g')
 .description('Generates new code for client and server from blueprints')
-.action(function(blueprint, name, attributes){ commands.generate(blueprint, name, attributes, leek) });
+.action(function(blueprint, name, attributes, options){ commands.generate(blueprint, name, attributes, options, leek) });
 
 //TODO: sync command: Farily complex. Needs to check which models exist on the client-side, which on the server-side
 // and then create all the one that don't exist on either side and the rest make sure they are the same.

--- a/lib/commands/generate.js
+++ b/lib/commands/generate.js
@@ -6,11 +6,15 @@ var trackCommand = require('../tasks/trackCommand');
 
 var supportedBlueprints = ['api', 'resource'];
 
-module.exports = function generate(blueprint, name, attributes, leek) {
+module.exports = function generate(blueprint, name, attributes, options, leek) {
   trackCommand(`generate ${blueprint} ${name} ${attributes}`, {}, leek);
   if (supportedBlueprints.indexOf(blueprint) > -1) {
     if (name !== undefined) {
-      var emberOptions = ['g', 'resource', name].concat(modelConversion.toEmber(attributes));
+
+      var prepEmberOptions = ['g', 'resource', name];
+      options.pod ? prepEmberOptions.push('--pod') : false;
+
+      var emberOptions = prepEmberOptions.concat(modelConversion.toEmber(attributes));
       var sailsOptions = ['generate', 'model', name].concat(modelConversion.toSails(attributes));
 
       var ember = spawn('ember', emberOptions, { cwd: 'client', stdio: 'inherit', env: process.env });


### PR DESCRIPTION
I think this commit adds support for ember pods to the generator without breaking anything (as far as I could tell). The only caveat is that the users need to add a podModulePrefix key to ENV config/environment.js  as described in the ember-cli docs 'pods' section. I wasn't sure if I can add a config to the template like the adapter and serializer etc. That could be one improvement if deemed necessary. 
