### PR TITLE
[ENHANCEMENT] Use ShellJS makefile for linting and testing

### DIFF
--- a/makefile.js
+++ b/makefile.js
@@ -1,0 +1,82 @@
+/*global exit, target*/
+
+'use strict';
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+require('shelljs/make');
+var chalk = require('chalk');
+var which = require('npm-which')(process.cwd());
+var spawn = require('child_process').spawnSync;
+
+
+//------------------------------------------------------------------------------
+// Data
+//------------------------------------------------------------------------------
+
+var NODE = which.sync('node');
+var ESLINT = which.sync('eslint');
+
+// var SOURCE_DIR = 'src';
+// var BUILD_DIR = 'lib';
+var SOURCE_DIR = 'lib';
+var TEST_DIR = 'tests';
+var SANE_BIN = 'bin/sane';
+
+var TEST_RUNNER = 'tests/runner';
+var UNIT_OPT = 'unit';
+var ACCEPTANCE_OPT = 'acceptance';
+
+
+//------------------------------------------------------------------------------
+// Tasks
+//------------------------------------------------------------------------------
+
+target.lint = function () {
+  var lastReturn;
+  var errors = 0;
+
+  process.stdout.write('Linting Source Files ');
+  lastReturn = spawn(ESLINT, [SOURCE_DIR, SANE_BIN], { stdio: 'inherit' });
+  if (lastReturn.status !== 0) {
+    errors++;
+  } else {
+    console.log(chalk.green('OK'));
+  }
+
+  process.stdout.write('Linting Test Files ');
+  lastReturn = spawn(ESLINT, [TEST_DIR], { stdio: 'inherit' });
+  if (lastReturn.status !== 0) {
+    errors++;
+  } else {
+    console.log(chalk.green('OK'));
+  }
+
+  if (errors) {
+    console.error(chalk.red('ERR!'), 'Linting failed.  See above for details.');
+    exit();
+  }
+
+};
+
+target.test = function () {
+  target.lint();
+  var lastReturn;
+  var errors = 0;
+
+  console.log('Running Unit Tests');
+  lastReturn = spawn(NODE, [TEST_RUNNER, UNIT_OPT], { stdio: 'inherit' });
+  errors = errors + lastReturn.status;
+
+  console.log('Running Acceptance Tests');
+  lastReturn = spawn(NODE, [TEST_RUNNER, ACCEPTANCE_OPT], { stdio: 'inherit' });
+  errors = errors + lastReturn.status;
+
+  if (errors) {
+    console.error(chalk.red('ERR!'), errors, 'test(s) failed.  See above for details.');
+    exit();
+  }
+
+};

--- a/package.json
+++ b/package.json
@@ -5,9 +5,8 @@
   "description": "A command-line tool for creating full stack sails-ember applications using docker",
   "main": "bin/sane",
   "scripts": {
-    "lint": "eslint bin/sane lib tests",
-    "pretest": "npm run lint",
-    "test": "node tests/runner",
+    "lint": "node makefile.js lint",
+    "test": "node makefile.js test",
     "test-all": "node tests/runner all",
     "autotest": "mocha --watch --reporter spec tests/**/*Test.js"
   },
@@ -70,6 +69,7 @@
     "mocha": "^2.0.1",
     "node-require-timings": "0.0.2",
     "rsvp": "^3.0.14",
+    "shelljs": "^0.4.0",
     "tmp-sync": "^1.0.1"
   },
   "preferGlobal": true

--- a/tests/runner.js
+++ b/tests/runner.js
@@ -3,7 +3,6 @@
 
 var glob  = require('glob');
 var Mocha = require('mocha');
-var chalk = require('chalk');
 var root;
 
 require('traceur').require.makeDefault(function (filename) {
@@ -25,6 +24,8 @@ if (!arg) {
   var root = 'tests/{unit,acceptance}';
 } else if (arg === 'unit') {
   var root = 'tests/unit';
+} else if (arg === 'acceptance') {
+  var root = 'tests/acceptance';
 } else {
   root = 'tests/{unit,acceptance}';
 }
@@ -37,13 +38,6 @@ addFiles(mocha, '/**/*Test.js');
 
 mocha.run(function (failures) {
   process.on('exit', function () {
-    if (failures === 1) {
-      console.log(chalk.red('1 Failing Test'));
-    } else if (failures > 1) {
-      console.log(chalk.red(failures, 'Failing Tests'));
-    } else if (failures === 0) {
-      console.log(chalk.green('All Tests Passed!'));
-    }
     process.exit(failures);
   });
 });


### PR DESCRIPTION
This cleans up the output when linting and running tests, and allows greater
flexibility for future additions as well (such as a build process for Babel
compilation).

This approach was inspired heavily by ESLint: https://github.com/eslint/eslint/blob/master/Makefile.js

Sample Output (missing colors):

```
▶ npm test

> sane-cli@0.0.24 test /mnt/sdb1/code/dev/sane
> node makefile.js test

Linting Source Files OK
Linting Test Files OK
Running Unit Tests


  new command
    ✓ doesn't allow to create an application with a period in the name (887ms)

  Unit: ember helper
    ✓ returns a value
    ✓ returns local ember by default


  3 passing (895ms)

Running Acceptance Tests


  Acceptance: sane generate
    ✓ resource/api user (7301ms)
    ✓ resource/api user name-string age-number (7510ms)
    ✓ should generate a singular sails model  when passed a singular value (7631ms)
    ✓ should generate a singular sails model when passed a plural value (7252ms)
    ✓ should generate a singular ember model when passed a singular value (7385ms)
    ✓ should generate a singular ember model when passed a plural value (7493ms)
    ✓ should generate a singular sails controller when passed a singular value (7317ms)
    ✓ should generate a singular sails controller when passed a plural value (7304ms)
    ✓ should generate a singular ember route when passed a singular value (7331ms)
    ✓ should generate a plural ember route when passed a plural value (7290ms)
    ✓ should generate a singular ember template when passed a singular value (7278ms)
    ✓ should generate a plural ember template when passed a plural value (7345ms)

  Acceptance: sane help
    ✓ displays commands, it's aliases and the correct cli version (931ms)

  Acceptance: sane new
    ✓ sane new . in empty folder works and adds specified dependencies to server package.json (5232ms)
    ✓ sane new facebook -d postgres, where facebook does not yet exist, works and adds settings to docker-compose.yml (5430ms)
    ✓ sane new myspace -d redis, where myspace does not exist, works and creates myspace with redis (5464ms)


  16 passing (2m)

```

I broke out the unit and acceptance tests, just for more control over the sequence I suppose.

The previous output (notice the crud at the top):

```
▶ npm test

> sane-cli@0.0.24 pretest /mnt/sdb1/code/dev/sane
> npm run lint


> sane-cli@0.0.24 lint /mnt/sdb1/code/dev/sane
> eslint bin/sane lib tests


> sane-cli@0.0.24 test /mnt/sdb1/code/dev/sane
> node tests/runner



  Acceptance: sane generate
    ✓ resource/api user (7372ms)
    ✓ resource/api user name-string age-number (7500ms)
    ✓ should generate a singular sails model  when passed a singular value (7394ms)
    ✓ should generate a singular sails model when passed a plural value (7343ms)
    ✓ should generate a singular ember model when passed a singular value (7410ms)
    ✓ should generate a singular ember model when passed a plural value (7417ms)
    ✓ should generate a singular sails controller when passed a singular value (7523ms)
    ✓ should generate a singular sails controller when passed a plural value (7458ms)
    ✓ should generate a singular ember route when passed a singular value (7390ms)
    ✓ should generate a plural ember route when passed a plural value (7277ms)
    ✓ should generate a singular ember template when passed a singular value (7482ms)
    ✓ should generate a plural ember template when passed a plural value (7583ms)

  Acceptance: sane help
    ✓ displays commands, it's aliases and the correct cli version (967ms)

  Acceptance: sane new
    ✓ sane new . in empty folder works and adds specified dependencies to server package.json (6502ms)
    ✓ sane new facebook -d postgres, where facebook does not yet exist, works and adds settings to docker-compose.yml (5582ms)
    ✓ sane new myspace -d redis, where myspace does not exist, works and creates myspace with redis (5533ms)

  new command
    ✓ doesn't allow to create an application with a period in the name (892ms)

  Unit: ember helper
    ✓ returns a value
    ✓ returns local ember by default


  19 passing (2m)

All Tests Passed!

```
